### PR TITLE
Make the code Google App Engine compatible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,10 @@ licensing {
     }
 }
 
+tasks.compileJava {
+    options.release.set(7)
+}
+
 sourceSets {
     main {
         java {


### PR DESCRIPTION
Added setting for java7 compatibility runtime version - without this I could not add it into my app engine project (there is an exception being thrown about incompatible java version in class files - app engine doesn't have support for new java runtimes - yet)...

If you need to support newer java versions, could you please release this as some "java7" or something like that version so I can get it from the official maven repo - instead of installing it locally into mine :) thanks!